### PR TITLE
Update Scala and sbt versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -453,8 +453,7 @@ lazy val `baker-http-dashboard`: Project = project.in(file("http/baker-http-dash
       val targetZipFile = target.value / "dashboard.zip"
       IO.zip(
         sources = (inputDirectory ** "*").get().map(f => (f, inputDirectory.relativize(f).get.toString)),
-        outputZip = targetZipFile,
-        time = None)
+        outputZip = targetZipFile)
       targetZipFile
     },
     prefixedDashboardResources := {

--- a/build.sbt
+++ b/build.sbt
@@ -39,8 +39,7 @@ lazy val buildExampleDockerCommand: Command = Command.command("buildExampleDocke
       state
 })
 
-//lazy val scala212 = "2.12.16"
-lazy val scala213 = "2.13.8"
+lazy val scala213 = "2.13.14"
 
 lazy val supportedScalaVersions = List(scala213)
 val commonSettings: Seq[Setting[_]] = Defaults.coreDefaultSettings ++ Seq(

--- a/core/baker-interface/src/main/scala/com/ing/baker/runtime/javadsl/Baker.scala
+++ b/core/baker-interface/src/main/scala/com/ing/baker/runtime/javadsl/Baker.scala
@@ -378,7 +378,7 @@ class Baker(private val baker: scaladsl.Baker) extends common.Baker[CompletableF
   def registerEventListener(@Nonnull eventListener: EventListener): Future[Unit] =
     baker.registerEventListener((recipeEventMetadata: scaladsl.RecipeEventMetadata, event: String) =>
       eventListener.processEvent(recipeEventMetadata.recipeInstanceId, event))
-1
+
   /**
     * Registers a listener that listens to all Baker events
     *

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.10.1


### PR DESCRIPTION
* Upgrade to scala 2.13.14
* Upgrade to sbt 1.10.1
* Fix (switch to the deprecated IO.zip signature) the depedency conflict on the sbt.io package in the meta-build phase when used together with Metals plugin which adds sbt-bloop to the project.